### PR TITLE
chore: oss-license 의존성 build-logic 에 합체

### DIFF
--- a/build-logic/src/main/kotlin/AndroidApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidApplicationPlugin.kt
@@ -13,11 +13,14 @@ import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 import team.duckie.quackquack.convention.ApplicationConstants
 import team.duckie.quackquack.convention.PluginEnum
 import team.duckie.quackquack.convention.applyPlugins
 import team.duckie.quackquack.convention.configureApplication
 import team.duckie.quackquack.convention.getPlaygroundVersion
+import team.duckie.quackquack.convention.implementations
+import team.duckie.quackquack.convention.libs
 
 /**
  * Android 프레임워크의 Application 환경을 구성합니다.
@@ -30,6 +33,7 @@ internal class AndroidApplicationPlugin : Plugin<Project> {
             applyPlugins(
                 PluginEnum.AndroidApplication,
                 PluginEnum.AndroidKotlin,
+                libs.findPlugin("oss-license").get().get().pluginId,
             )
 
             extensions.configure<BaseAppModuleExtension> {
@@ -42,6 +46,13 @@ internal class AndroidApplicationPlugin : Plugin<Project> {
                     this.versionName = versionName
                     this.versionCode = versionCode
                 }
+
+            }
+
+            dependencies {
+                implementations(
+                    libs.findLibrary("util-oss-license").get(),
+                )
             }
         }
     }

--- a/playground/build.gradle.kts
+++ b/playground/build.gradle.kts
@@ -14,7 +14,6 @@ plugins {
     id(ConventionEnum.AndroidApplication)
     id(ConventionEnum.AndroidApplicationCompose)
     id(ConventionEnum.JvmDokka)
-    id(libs.plugins.oss.license.get().pluginId)
 }
 
 android {
@@ -47,7 +46,6 @@ android {
 dependencies {
     implementations(
         libs.ktx.core,
-        libs.util.oss.license,
         libs.util.systemuicontroller,
         libs.compose.material3,
         libs.androidx.appcompat,


### PR DESCRIPTION
## Overview (Required)

- oss-license 의존성을 AndroidApplicationPlugin build-logic 으로 합쳤습니다.
