### PR TITLE
refactor: QuackText 코드 정리

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "
 kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version.ref = "kotlin-metadata" }
 kotlin-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlin-collections-immutable" }
 
+compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "compose-core" }
 compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose-core" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "compose-activity" }
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose-core" }

--- a/ui-components/build.gradle.kts
+++ b/ui-components/build.gradle.kts
@@ -34,6 +34,7 @@ android {
 dependencies {
     implementations(
         libs.compose.coil,
+        libs.compose.ui.util,
         libs.compose.material,
         libs.compose.accompanist.flowlayout,
         // projects.uxWritingModel,

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/internal/QuackText.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/internal/QuackText.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.util.fastForEach
 import kotlinx.collections.immutable.PersistentList
 import team.duckie.quackquack.ui.animation.QuackAnimatedContentTransform
 import team.duckie.quackquack.ui.component.HighlightTextInfo
@@ -26,10 +27,13 @@ import team.duckie.quackquack.ui.textstyle.animatedQuackTextStyleAsState
  * 주어진 조건에 따라 텍스트를 표시합니다. 꽥꽥에서 텍스트를 표시하는데
  * 사용되는 최하위 컴포넌트 입니다.
  *
- * **[QuackTextStyle] 의 모든 요소들에 자동으로 애니메이션이 적용됩니다.**
+ * **애니메이션 가능한 모든 요소들에는 자동으로 애니메이션이 적용됩니다.**
+ * 현재 애니메이션이 적용되는 요소들은 다음과 같습니다.
+ *
+ * [text], [style]
  *
  * @param modifier 이 컴포저블에서 사용할 [Modifier]
- * @param text 표시할 텍스트 내용
+ * @param text 표시할 텍스트
  * @param style 텍스트를 그릴 [TextStyle] 의 QuackQuack 버전
  * @param singleLine 텍스트를 한 줄로 표시할지 여부
  */
@@ -47,26 +51,6 @@ internal fun QuackText(
 
     QuackAnimatedContentTransform(
         modifier = modifier,
-        /*.lifecycle(
-                    key = text,
-                    onAppear = { offset ->
-                        quackTexts.add(
-                            QuackWrting(
-                                text = text,
-                                offset = offset,
-                            )
-                        )
-                        println("A! $offset")
-                    },
-                    onDisappear = {
-                        quackTexts.remove(
-                            quackTexts.first { quackText ->
-                                quackText.text == text
-                            }
-                        )
-                        println("B! $quackTexts")
-                    },
-                )*/
         targetState = text,
     ) { animatedText ->
         BasicText(
@@ -82,23 +66,23 @@ internal fun QuackText(
 }
 
 /**
- * 주어진 조건에 따라 텍스트를 표시합니다. 꽥꽥에서 텍스트를 표시하는데
- * 사용되는 최하위 컴포넌트 입니다.
+ * 주어진 조건에 따라 텍스트를 표시합니다.
+ * 꽥꽥에서 텍스트를 표시하는데 사용되는 최하위 컴포넌트 입니다.
  *
  * **애니메이션 가능한 모든 요소들에는 자동으로 애니메이션이 적용됩니다.**
  * 현재 애니메이션이 적용되는 요소들은 다음과 같습니다.
  *
- * [text], [style]
+ * [annotatedText], [style]
  *
  * @param modifier 이 컴포저블에서 사용할 [Modifier]
- * @param text 표시할 텍스트 내용
+ * @param annotatedText 표시할 텍스트
  * @param style 텍스트를 그릴 [TextStyle] 의 QuackQuack 버전
  * @param singleLine 텍스트를 한 줄로 표시할지 여부
  */
 @Composable
 internal fun QuackText(
     modifier: Modifier = Modifier,
-    text: AnnotatedString,
+    annotatedText: AnnotatedString,
     style: QuackTextStyle,
     singleLine: Boolean = false,
     overflow: TextOverflow = TextOverflow.Clip,
@@ -109,27 +93,7 @@ internal fun QuackText(
 
     QuackAnimatedContentTransform(
         modifier = modifier,
-        /*.lifecycle(
-                    key = text,
-                    onAppear = { offset ->
-                        quackTexts.add(
-                            QuackWrting(
-                                text = text,
-                                offset = offset,
-                            )
-                        )
-                        println("A! $offset")
-                    },
-                    onDisappear = {
-                        quackTexts.remove(
-                            quackTexts.first { quackText ->
-                                quackText.text == text
-                            }
-                        )
-                        println("B! $quackTexts")
-                    },
-                )*/
-        targetState = text,
+        targetState = annotatedText,
     ) { animatedText ->
         BasicText(
             text = animatedText,
@@ -149,7 +113,7 @@ internal fun QuackText(
  * @param modifier 이 컴포저블에서 사용할 [Modifier]
  * @param text 표시할 텍스트 내용
  * @param clickEventTextInfo 클릭 이벤트 처리용 텍스트 목록
- * @param defaultOnClick [clickEventTextInfo] 목록 내 모든 range 에 속하지 않을 때 실행해 줄 클릭 이벤트
+ * @param defaultOnClick [clickEventTextInfo] 목록 내 모든 range 에 속하지 않을 때 실행할 클릭 이벤트
  * @param style 텍스트를 그릴 [TextStyle] 의 QuackQuack 버전
  * @param singleLine 텍스트를 한 줄로 표시할 지 여부
  * @param overflow 텍스트 overflow 될 시 처리 방법
@@ -169,8 +133,12 @@ internal fun QuackClickableText(
         text = text,
         style = style.asComposeStyle(),
         onClick = { offset ->
-            clickEventTextInfo.forEach { (value, _, _, onClick) ->
-                text.getStringAnnotations(value, offset, offset).firstOrNull()?.let {
+            clickEventTextInfo.fastForEach { (value, _, _, onClick) ->
+                text.getStringAnnotations(
+                    tag = value,
+                    start = offset,
+                    end = offset,
+                ).firstOrNull()?.let {
                     onClick?.invoke()
                     return@ClickableText
                 }

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/typography.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/typography.kt
@@ -390,7 +390,7 @@ public fun QuackUnderlineHeadLine2(
             rippleEnabled = rippleEnabled,
             onClick = onClick,
         ),
-        text = buildAnnotatedString {
+        annotatedText = buildAnnotatedString {
             append(text)
             underlineText.forEach { highlightText ->
                 val highlightStartIndex = text.indexOf(
@@ -451,7 +451,7 @@ public fun QuackUnderlineBody3(
             rippleEnabled = rippleEnabled,
             onClick = onClick,
         ),
-        text = buildAnnotatedString {
+        annotatedText = buildAnnotatedString {
             append(text)
             underlineText.forEach { highlightText ->
                 val highlightStartIndex = text.indexOf(
@@ -511,7 +511,7 @@ public fun QuackHighlightBody1(
             rippleEnabled = rippleEnabled,
             onClick = onClick,
         ),
-        text = buildAnnotatedString {
+        annotatedText = buildAnnotatedString {
             append(text)
             highlightText.forEach { highlightText ->
                 val highlightStartIndex = text.indexOf(

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/textstyle/QuackTextStyle.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/textstyle/QuackTextStyle.kt
@@ -188,8 +188,9 @@ public class QuackTextStyle internal constructor(
  * @receiver Sp 로 변환할 [Float]
  * @return receiver 로 받은 [Float] 를 [TextUnit] 중 Sp 로 변환한 값
  */
+@Suppress("NOTHING_TO_INLINE")
 @Stable
-private fun Float.toSp() = TextUnit(
+private inline fun Float.toSp() = TextUnit(
     value = this,
     type = TextUnitType.Sp,
 )


### PR DESCRIPTION
## Overview (Required)

- compose-ui-util 의존성 추가
- `Float.toSp()` 최적화
- `QuackText` 에서 사용되지 않는 코드 정리
- `QuackText` 문서화 보충
- 중복되는 `text` 인자명 `annotatedText` 으로 변경