### PR TITLE
ui-components 모듈의 baseline-prof 생성 시 모듈에 해당하는 줄만 남기도록 변경

### DIFF
--- a/.github/workflows/artifact-stable-publish.yml
+++ b/.github/workflows/artifact-stable-publish.yml
@@ -99,9 +99,9 @@ jobs:
       - name: Move baseline profile
         if: ${{ steps.label.outputs.release_target == 'UiComponents' }}
         run: >
-          mv
-          ui-components-benchmark/build/outputs/managed_device_android_test_additional_output/pixel6Api31/BaselineProfileGenerator_startup-baseline-prof.txt
-          ui-components/src/main/baseline-prof.txt
+          cat
+          ui-components-benchmark/build/outputs/managed_device_android_test_additional_output/pixel6Api31/BaselineProfileGenerator_startup-baseline-prof.txt |
+          grep "team/duckie/quackquack/ui" > ui-components/src/main/baseline-prof.txt
 
       - name: Bump version
         run: ./gradlew bump -Ptype=${{ steps.label.outputs.bump_type }} -Ptarget=${{ steps.label.outputs.release_target }}


### PR DESCRIPTION
## Issue

- close #369 

## Overview
생성된 baseline-prof.txt 파일을 보면, team.duckie.quackquack.ui 패키지 하위 파일 뿐만 아니라 benchmark app 실행을 위해 딸려온 부수적인 부분이 함께 존재한다. 

Jetpack 라이브러리([예시](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/foundation/foundation/src/androidMain/baseline-prof.txt))의 baseline-prof.txt를 보면 가이드를 따라 만들어진 baseline-prof.txt와 다르게 필요한 부분만 적혀있다는 인상을 받았다.

그에 따라 생성된 baseline-prof.txt에서 src/main으로 파일을 옮기는 스크립트를 수정해 목적을 달성했다.

## Screenshot
현재 [master 브랜치의 baseline-prof.txt](https://github.com/duckie-team/quack-quack-android/blob/master/ui-components/src/main/baseline-prof.txt)를 변경사항의 명령어로 실행한 모습
<img width="1732" alt="image" src="https://user-images.githubusercontent.com/7759511/202335413-f1caddfc-14c1-4531-a390-c0bc156d8ad0.png">

## 위 결과물 파일
[new-baseline-prof.txt](https://github.com/duckie-team/quack-quack-android/files/10027071/new-baseline-prof.txt)