### PR TITLE
feat: fix design detail

### DIFF
--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/ImagePlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/ImagePlayground.kt
@@ -33,7 +33,7 @@ class ImagePlayground : PlaygroundActivity(
     override val items: ImmutableList<Pair<String, @Composable () -> Unit>> = persistentListOf(
         ::QuackImageDemo.name to { QuackImageDemo() },
         ::QuackSelectableImageTypeTopEndCheckboxDemo.name to { QuackSelectableImageTypeTopEndCheckboxDemo() },
-        ::QuackSelectableImageTypeCheckOverlayDemo.name to { QuackSelectableImageTypeCheckOverlayDemo() },
+        ::QuackSelectableImageTypeCheckOverlayWithRoundingDemo.name to { QuackSelectableImageTypeCheckOverlayWithRoundingDemo() },
     )
 }
 
@@ -85,7 +85,7 @@ fun QuackSelectableImageTypeTopEndCheckboxDemo() {
 }
 
 @Composable
-fun QuackSelectableImageTypeCheckOverlayDemo() {
+fun QuackSelectableImageTypeCheckOverlayWithRoundingDemo() {
     val context = LocalContext.current
     var selected by remember { mutableStateOf(false) }
 

--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TextFieldPlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TextFieldPlayground.kt
@@ -79,18 +79,13 @@ fun QuackBasic2TextFieldDemo() {
 @Composable
 fun QuackErrorableTextFieldDemo() {
     val (text, setText) = remember { mutableStateOf("") }
-    val isError by remember {
-        derivedStateOf {
-            text.length > 5
-        }
-    }
 
     QuackErrorableTextField(
         text = text,
         onTextChanged = setText,
         placeholderText = "MaxLength: 5",
         maxLength = 5,
-        isError = isError,
+        isError = text.length > 5,
         errorText = "ErrorText",
         showClearButton = true,
         onCleared = { setText("") },
@@ -100,18 +95,13 @@ fun QuackErrorableTextFieldDemo() {
 @Composable
 fun QuackErrorableTextFieldWithoutClearButtonDemo() {
     val (text, setText) = remember { mutableStateOf("") }
-    val isError by remember {
-        derivedStateOf {
-            text.length > 5
-        }
-    }
 
     QuackErrorableTextField(
         text = text,
         onTextChanged = setText,
         placeholderText = "MaxLength: 5",
         maxLength = 5,
-        isError = isError,
+        isError = text.length > 5,
         errorText = "ErrorText",
     )
 }

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/image.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/image.kt
@@ -7,6 +7,7 @@
 
 package team.duckie.quackquack.ui.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -394,9 +395,8 @@ public fun QuackSelectableImage(
     QuackSurface(
         modifier = modifier,
         shape = shape,
-        border = borderFor(
-            isSelected = isSelected,
-        ),
+        border = borderFor(isSelected = isSelected)
+            .takeIf { selectableType == TopEndCheckBox },
         rippleEnabled = rippleEnabled,
         onClick = onClick,
         contentAlignment = Alignment.TopEnd,
@@ -428,7 +428,9 @@ public fun QuackSelectableImage(
                     visible = isSelected,
                 ) {
                     Box(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(color = QuackColor.Dimmed.composeColor),
                         contentAlignment = Alignment.Center,
                     ) {
                         QuackImage(

--- a/versions/ui-components.txt
+++ b/versions/ui-components.txt
@@ -1,3 +1,3 @@
 major=1
 minor=3
-patch=1
+patch=2


### PR DESCRIPTION
## Overview (Required)

- TextField playground 에서 `isError` 상태 문제를 해결하였습니다.
- QuackSelectableImage 의 디자인 디테일을 일부 개선하였습니다.
