### PR TITLE
feat: QuackBasic2TextField 문제 수정

### DIFF
--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TextFieldPlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TextFieldPlayground.kt
@@ -27,7 +27,7 @@ class TextFieldPlayground : PlaygroundActivity(
     override val items: ImmutableList<Pair<String, @Composable () -> Unit>> = persistentListOf(
         ::QuackBasicTextFieldDemo.name to { QuackBasicTextFieldDemo() },
         ::QuackPriceTextFieldDemo.name to { QuackPriceTextFieldDemo() },
-        ::QuackBasic2TextFieldDemo.name to { QuackBasic2TextFieldDemo() },
+        ::QuackBasic2TextFieldPadding10Demo.name to { QuackBasic2TextFieldPadding10Demo() },
         ::QuackErrorableTextFieldDemo.name to { QuackErrorableTextFieldDemo() },
         ::QuackErrorableTextFieldWithoutClearButtonDemo.name to { QuackErrorableTextFieldWithoutClearButtonDemo() },
     )
@@ -59,17 +59,18 @@ fun QuackPriceTextFieldDemo() {
     )
 }
 
-private val QuackBasic2TextFieldDecorationItemsHorizontalPadding = 5.dp
+private val QuackBasic2TextFieldDecorationItemsHorizontalPadding = 10.dp
 
 @Composable
-fun QuackBasic2TextFieldDemo() {
+fun QuackBasic2TextFieldPadding10Demo() {
     val toast = rememberToast()
     val (text, setText) = remember { mutableStateOf("") }
 
     QuackBasic2TextField(
         text = text,
         onTextChanged = setText,
-        placeholderText = "decoration items horizontal padding: 5.dp",
+        placeholderText = "decoration items horizontal padding:" +
+                " ${QuackBasic2TextFieldDecorationItemsHorizontalPadding}.dp",
         leadingStartPadding = QuackBasic2TextFieldDecorationItemsHorizontalPadding,
         leadingIcon = QuackIcon.Heart,
         leadingIconOnClick = { toast("Heart clicked") },

--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TextFieldPlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TextFieldPlayground.kt
@@ -69,8 +69,8 @@ fun QuackBasic2TextFieldPadding10Demo() {
     QuackBasic2TextField(
         text = text,
         onTextChanged = setText,
-        placeholderText = "decoration items horizontal padding:" +
-                " ${QuackBasic2TextFieldDecorationItemsHorizontalPadding}.dp",
+        placeholderText = "decoration items horizontal padding: " +
+                "$QuackBasic2TextFieldDecorationItemsHorizontalPadding.dp",
         leadingStartPadding = QuackBasic2TextFieldDecorationItemsHorizontalPadding,
         leadingIcon = QuackIcon.Heart,
         leadingIconOnClick = { toast("Heart clicked") },

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/TextField.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/TextField.kt
@@ -368,22 +368,18 @@ private object QuackTextFieldDefaults {
             startPadding: Dp,
             icon: QuackIcon?,
             onClick: (() -> Unit)?,
-        ): (@Composable () -> Unit)? {
-            return if (icon == null) {
-                null
-            } else {
-                {
-                    Row {
-                        Spacer(modifier = Modifier.width(startPadding))
-                        QuackImage(
-                            padding = LeadingIconPadding,
-                            src = icon,
-                            size = LeadingIconSize,
-                            tint = LeadingIconTint,
-                            rippleEnabled = false,
-                            onClick = onClick,
-                        )
-                    }
+        ): @Composable () -> Unit {
+            return {
+                Row {
+                    Spacer(modifier = Modifier.width(startPadding))
+                    QuackImage(
+                        padding = LeadingIconPadding,
+                        src = icon,
+                        size = LeadingIconSize,
+                        tint = LeadingIconTint,
+                        rippleEnabled = false,
+                        onClick = onClick,
+                    )
                 }
             }
         }
@@ -404,26 +400,22 @@ private object QuackTextFieldDefaults {
         fun TrailingIcon(
             endPadding: Dp,
             icon: QuackIcon?,
-            isEnabled: Boolean?,
+            isEnabled: Boolean,
             onClick: (() -> Unit)?,
-        ): (@Composable () -> Unit)? {
-            return if (icon == null || isEnabled == null) {
-                null
-            } else {
-                {
-                    Row {
-                        QuackImage(
-                            padding = TrailingIconPadding,
-                            src = icon,
-                            size = TrailingIconSize,
-                            tint = trailinIconTintFor(
-                                isEnabled = isEnabled,
-                            ),
-                            rippleEnabled = false,
-                            onClick = onClick,
-                        )
-                        Spacer(modifier = Modifier.width(endPadding))
-                    }
+        ): @Composable () -> Unit {
+            return {
+                Row {
+                    QuackImage(
+                        padding = TrailingIconPadding,
+                        src = icon,
+                        size = TrailingIconSize,
+                        tint = trailinIconTintFor(
+                            isEnabled = isEnabled,
+                        ),
+                        rippleEnabled = false,
+                        onClick = onClick,
+                    )
+                    Spacer(modifier = Modifier.width(endPadding))
                 }
             }
         }

--- a/versions/ui-components.txt
+++ b/versions/ui-components.txt
@@ -1,3 +1,3 @@
 major=1
 minor=3
-patch=4
+patch=5


### PR DESCRIPTION
## Overview (Required)

- QuackBasic2TextField 에서 decoration items 가 없으면 decoration horizontal padding 이 적용되지 않던 문제 수정